### PR TITLE
Adding group stratifying in nComps selection

### DIFF
--- a/find_optimal_comp_groups.R
+++ b/find_optimal_comp_groups.R
@@ -1,0 +1,96 @@
+##Same function as find_optimal_components but just with an additional argument (groups)
+## and using the new function pls_permut_by_group instead of pls_permutation
+
+##Stratifying is only included in firstMin and firstPlateau, maybe pls could be eliminated...
+##or otherwise some way of stratifying should be included in the pls method (I don't know how).
+
+
+## groups should be an vector of caracters of the form c("var1", "var2"..."varn")
+##I have not included any control for this condition, though
+
+##Changed commands marked 
+
+find_optimal_comp_groups <- function (dataset = NULL, method = "pls", maxComps = 20, 
+          iterations = 20, seg = 100, prop = 0.7, random_seed = 123456789, groups=NULL) 
+{
+  set.seed(random_seed)
+  if (method == "pls") {
+    print("*** Running PLS permutation test ***")
+    plsr.out <- pls::plsr(as.formula(paste(inVar, "~", 
+                                           "Spectra")), scale = FALSE, center = TRUE, 
+                          ncomp = maxComps, validation = "CV", segments = seg, 
+                          segment.type = "interleaved", trace = FALSE, 
+                          jackknife = TRUE, data = cal.plsr.data)
+    nComps <- selectNcomp(plsr.out, method = "onesigma", 
+                          plot = TRUE)
+  }
+  if (method == "firstPlateau") {
+##Changed pls_permutation for pls_permut_by_groups    
+    press.out <- spectratrait::pls_permut_by_groups(dataset = dataset, 
+                                               maxComps = maxComps, iterations = iterations, prop = prop, groups=groups)
+    pressDF <- as.data.frame(press.out$PRESS)
+    names(pressDF) <- as.character(seq(maxComps))
+    pressDFres <- reshape2::melt(pressDF)
+    results <- NULL
+    for (i in 1:(maxComps - 1)) {
+      p_value <- t.test(press.out$PRESS[, i], press.out$PRESS[, 
+                                                              (i + 1)])$p.value
+      temp_results <- data.frame(Component = (i + 1), P.value = round(p_value, 
+                                                                      6))
+      results <- rbind(results, temp_results)
+    }
+    nComps <- min(results[results$P.value > 0.05, "Component"])
+    print(paste0("*** Optimal number of components based on t.test: ", 
+                 nComps))
+    bp <- ggplot(pressDFres, aes(x = variable, y = value)) + 
+      theme_bw() + geom_boxplot(notch = FALSE) + labs(x = "Number of Components", 
+                                                      y = "PRESS") + stat_boxplot(geom = "errorbar", 
+                                                                                  width = 0.2) + geom_vline(xintercept = nComps, linetype = "dashed", 
+                                                                                                            color = "blue", size = 1)
+    theme(axis.text = element_text(size = 18), legend.position = "none", 
+          axis.title = element_text(size = 20, face = "bold"), 
+          axis.text.x = element_text(angle = 0, vjust = 0.5), 
+          panel.border = element_rect(linetype = "solid", 
+                                      fill = NA, size = 1.5))
+    print(bp)
+  }
+  if (method == "firstMin") {
+##Changed pls_permutation for pls_permut_by_groups
+    press.out <- spectratrait::pls_permut_by_goups(dataset = dataset, 
+                                               maxComps = maxComps, iterations = iterations, prop = prop, groups=groups)
+    pressDF <- as.data.frame(press.out$PRESS)
+    names(pressDF) <- as.character(seq(maxComps))
+    pressDFres <- reshape2::melt(pressDF)
+    mean_PRESS_comp <- apply(X = pressDF, MARGIN = 2, FUN = mean)
+    lowest_PRESS <- which.min(mean_PRESS_comp)
+    results <- as.vector(array(data = "NA", dim = c(lowest_PRESS - 
+                                                      1, 1)))
+    for (i in seq_along(1:(lowest_PRESS - 1))) {
+      comp1 <- i
+      comp2 <- lowest_PRESS
+      ttest <- t.test(pressDFres$value[which(pressDFres$variable == 
+                                               comp1)], pressDFres$value[which(pressDFres$variable == 
+                                                                                 comp2)])
+      results[i] <- round(unlist(ttest$p.value), 8)
+    }
+    results <- data.frame(seq(1, lowest_PRESS - 1, 1), results)
+    names(results) <- c("Component", "P.value")
+    first <- min(which(as.numeric(as.character(results$P.value)) > 
+                         0.05))
+    nComps <- results$Component[first]
+    print(paste0("*** Optimal number of components based on t.test: ", 
+                 nComps))
+    bp <- ggplot(pressDFres, aes(x = variable, y = value)) + 
+      theme_bw() + geom_boxplot(notch = FALSE) + labs(x = "Number of Components", 
+                                                      y = "PRESS") + stat_boxplot(geom = "errorbar", 
+                                                                                  width = 0.2) + geom_vline(xintercept = nComps, linetype = "dashed", 
+                                                                                                            color = "blue", size = 1)
+    theme(axis.text = element_text(size = 18), legend.position = "none", 
+          axis.title = element_text(size = 20, face = "bold"), 
+          axis.text.x = element_text(angle = 0, vjust = 0.5), 
+          panel.border = element_rect(linetype = "solid", 
+                                      fill = NA, size = 1.5))
+    print(bp)
+  }
+  return(nComps)
+}

--- a/pls_permut_by_groups.R
+++ b/pls_permut_by_groups.R
@@ -1,0 +1,74 @@
+##Same function as pls_permutation but just with an additional argument (groups),
+## and a new sampling approach which takes into account the input groups
+
+##Stratifying is only included if groups is not null
+##A dplyr approach is used to do the by-group sampling
+
+
+## groups should be an vector of caracters of the form c("var1", "var2"..."varn")
+##I have not included any control for this condition, though
+
+##Changed commands marked 
+
+
+
+pls_permut_by_groups <- function (dataset = NULL, maxComps = 20, iterations = 20, prop = 0.7, 
+          verbose = FALSE, groups=NULL) 
+{
+  coefs <- array(0, dim = c((ncol(dataset$Spectra) + 1), iterations, 
+                            maxComps))
+  press.out <- array(data = NA, dim = c(iterations, maxComps))
+  print("*** Running permutation test.  Please hang tight, this can take awhile ***")
+  print("Options:")
+  print(paste("Max Components:", maxComps, "Iterations:", 
+              iterations, "Data Proportion (percent):", prop * 
+                100, sep = " "))
+  if (verbose) {
+    j <- 1
+    pb <- utils::txtProgressBar(min = 0, max = iterations, 
+                                char = "*", width = 70, style = 3)
+  }
+  for (i in seq_along(1:iterations)) {
+##New condition statement to select the sampling strategy (random or stratified) based on
+##the content of the group argument
+    if (!is.null(groups)) {
+##A new dataset is created for internal training by
+##creating a new Internal Id at the beginning,
+##grouping by the groups object,
+##and sampling within each group a number of cases equal to prop*n()
+##Then the selected values of the internal id is stored as the rows vector,
+##which is used to separate the training dataset and the validation data set
+##(unchanged from pls_permutation)
+      trainset<- dataset %>%
+        mutate(int_id = row_number()) %>%
+        group_by_at(groups) %>%
+        slice(sample(1:n(), prop * n())) 
+      rows<- trainset$int_id
+    } else {
+        rows <- sample(1:nrow(dataset), floor(prop * nrow(dataset)))
+    }
+    sub.data <- dataset[rows, ]
+    val.sub.data <- dataset[-rows, ]
+    plsr.out <- plsr(as.formula(paste(inVar, "~", "Spectra")), 
+                     scale = FALSE, center = TRUE, ncomp = maxComps, validation = "none", 
+                     data = sub.data)
+    pred_val <- predict(plsr.out, newdata = val.sub.data)
+    sq_resid <- (pred_val[, , ] - val.sub.data[, inVar])^2
+    press <- apply(X = sq_resid, MARGIN = 2, FUN = sum)
+    press.out[i, ] <- press
+    coefs[, i, ] <- coef(plsr.out, intercept = TRUE, ncomp = 1:maxComps)
+    rm(rows, sub.data, val.sub.data, plsr.out, pred_val, 
+       sq_resid, press)
+    if (verbose) {
+      setTxtProgressBar(pb, j)
+      j <- j + 1
+      flush.console()
+    }
+  }
+  if (verbose) {
+    close(pb)
+  }
+  print("*** Providing PRESS and coefficient array output ***")
+  output <- list(PRESS = press.out, coef_array = coefs)
+  return(output)
+}


### PR DESCRIPTION
A couple of functions to allow to include a stratifying variables in the sampling strategy used for the selection of optimal number of latent variables. pls_permut_by_groups is a changed version of pls::pls_permutation and find_optimal_comp_groups simply implements the use of pls_permut_by_groups instead of pls::pls_permutation.
Changes included in find_optimal_comp_groups could be incorporated, instead, in find_optimal_components.